### PR TITLE
Seasonal word: evidence dropdown

### DIFF
--- a/src/app/api/poems/route.prod.js
+++ b/src/app/api/poems/route.prod.js
@@ -15,7 +15,7 @@ async function getData (chapter, number){
 		resTag : 'match (g:Genji_Poem)-[:INCLUDED_IN]->(:Chapter {chapter_number: "' + chapter + '"}), (g)-[:TAGGED_AS]->(t:Tag) where g.pnum ends with "' + number + '" return t.Type as type',
 		resType : 'match (t:Tag) return t.Type as type',
 		resSeason : 'MATCH (g:Genji_Poem)-[:INCLUDED_IN]->(c:Chapter {chapter_number: "' + chapter + '"}), (g:Genji_Poem)-[r:IN_SEASON_OF]->(s:Season) WHERE g.pnum ends with "' + number + '" RETURN s.name as season, r.evidence as season_evidence',
-		resKigo : 'MATCH (g:Genji_Poem)-[:INCLUDED_IN]->(c:Chapter {chapter_number: "' + chapter + '"}), (g:Genji_Poem)-[:HAS_SEASONAL_WORD_OF]->(sw:Seasonal_Word) WHERE g.pnum ends with "' + number + '" RETURN sw.japanese as sw_jp, sw.english as sw_en',
+		resKigo : 'MATCH (g:Genji_Poem)-[:INCLUDED_IN]->(c:Chapter {chapter_number: "' + chapter + '"}), (g:Genji_Poem)-[r:HAS_SEASONAL_WORD_OF]->(sw:Seasonal_Word) WHERE g.pnum ends with "' + number + '" RETURN sw.japanese as sw_jp, sw.english as sw_en, r.evidence as sw_evidence',
 		resTech: 'MATCH (g:Genji_Poem)-[:INCLUDED_IN]->(c:Chapter {chapter_number: "' + chapter + '"}), (g:Genji_Poem)-[:EMPLOYS_POETIC_TECHNIQUE]->(pt:Poetic_Technique) WHERE g.pnum ends with "' + number + '" RETURN pt.name as pt_name',
 		resPoeticWord: 'MATCH (g:Genji_Poem)-[:INCLUDED_IN]->(c:Chapter {chapter_number: "' + chapter + '"}), (g:Genji_Poem)-[:HAS_POETIC_WORD_OF]->(pw:Poetic_Word) WHERE g.pnum ends with "' + number + '" RETURN pw.name as pw_name, pw.kanji_hiragana as kanji_hiragana, pw.gloss as gloss, pw.english_equiv as english_equiv',
 		resProxy: 'MATCH (g:Genji_Poem)-[:INCLUDED_IN]->(c:Chapter {chapter_number: "' + chapter + '"}), (g:Genji_Poem)<-[:PROXY_POET_OF]-(a:Character) WHERE g.pnum ends with "' + number + '" RETURN a.name as name',
@@ -95,6 +95,7 @@ async function getData (chapter, number){
 		const kigo = {
 			jp: result['resKigo'].records[0]?.get('sw_jp') || null,
 			en: result['resKigo'].records[0]?.get('sw_en') || null,
+			evidence: result['resKigo'].records[0]?.get('sw_evidence') || null,
 		};
 
 		// poetic technique

--- a/src/components/PoemQueryResults.prod.jsx
+++ b/src/components/PoemQueryResults.prod.jsx
@@ -74,8 +74,8 @@ const PoemDisplay = ({ poemData }) => {
         paperMediumType: "",
         deliveryStyle: "",
         season: "",
-        kigo: { jp: "", en: "" },
-        pt: "",
+        kigo: { jp: "", en: "", evidence: "" },
+        pt: [],
         pw: { name: "", kanji_hiragana: "", english_equiv: "", gloss: "" },
         messenger: "",
         age: "",
@@ -251,7 +251,7 @@ const PoemDisplay = ({ poemData }) => {
                     deliveryStyle: responseData[11],
                     season: responseData[12],
                     kigo: responseData[13],
-                    pt: responseData[14],
+                    pt: Array.isArray(responseData[14]) ? responseData[14] : [],
                     pw: responseData[15],
                     proxy: responseData[16],
                     // unused messenger
@@ -657,8 +657,12 @@ const PoemDisplay = ({ poemData }) => {
                                 {poemState.kigo && poemState.kigo.jp && (
                                     <div className={styles.detailItem}>
                                         <h3>SEASONAL WORD</h3>
-                                        <FormatContent content={`${poemState.kigo.jp}`} />
-                                        <FormatContent content={`${poemState.kigo.en}`} />
+                                        <div className={styles.withEvidence}>
+                                            <EvidenceDropdown
+                                                content={`${poemState.kigo.jp} – ${poemState.kigo.en || ''}`}
+                                                evidence={poemState.kigo.evidence || ''}
+                                            />
+                                        </div>
                                     </div>
                                 )}
                                 


### PR DESCRIPTION
- Changed the current seasonal word display to be "jp - en".
- Added evidence dropdown for seasonal word.
- Fixed pt so it's always an array to avoid .some() errors.