### PR TITLE
fix search highlight regex and hydration error

### DIFF
--- a/src/app/search/page.prod.jsx
+++ b/src/app/search/page.prod.jsx
@@ -1,8 +1,10 @@
 'use client'
 
 import { useParams } from 'next/navigation';
-import PoemSearch from "../../components/FilterSearch.prod"
+import dynamic from 'next/dynamic';
 import styles from "../../styles/pages/poemKeyWordSearchPageLayout.module.css";
+
+const PoemSearch = dynamic(() => import("../../components/FilterSearch.prod"), { ssr: false });
 
 export default function CharacterPage() {
     const params = useParams();

--- a/src/components/FilterSearch.prod.jsx
+++ b/src/components/FilterSearch.prod.jsx
@@ -269,9 +269,10 @@ const PoemSearch = () => {
   // highlight matching keywords
   const highlightMatch = (text, query) => {
     if (!query) return text;
-    const regex = new RegExp(`(${query})`, "gi");
+    const escapedQuery = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const regex = new RegExp(`(${escapedQuery})`, 'gi');
     return text.split(regex).map((part, index) =>
-      regex.test(part) ? (
+      index % 2 === 1 ? (
         <mark key={index} className={styles.highlight}>
           {part}
         </mark>

--- a/src/components/PoemKeywordSearch.prod.jsx
+++ b/src/components/PoemKeywordSearch.prod.jsx
@@ -38,9 +38,10 @@ const PoemSearch = () => {
   // highlight matching keywords
   const highlightMatch = (text, query) => {
     if (!query) return text;
-    const regex = new RegExp(`(${query})`, 'gi');
-    return text.split(regex).map((part, index) => 
-      regex.test(part) ? <mark key={index} className={styles.highlight}>{part}</mark> : part
+    const escapedQuery = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const regex = new RegExp(`(${escapedQuery})`, 'gi');
+    return text.split(regex).map((part, index) =>
+      index % 2 === 1 ? <mark key={index} className={styles.highlight}>{part}</mark> : part
     );
   };
 


### PR DESCRIPTION
Escape regex special characters in highlightMatch so queries like '. . .' match only literal text instead of acting as wildcards. Replace regex.test(part) with index parity check to avoid stateful lastIndex bug on global regexes that caused incorrect highlights.

Use dynamic import with ssr:false on the search page to resolve hydration mismatch caused by Ant Design Checkbox components rendering differently when sessionStorage is read during server-side render.