### PR TITLE
fix character list not reflecting Neo4j updates due to stale cache

### DIFF
--- a/src/app/api/character_names/route.prod.js
+++ b/src/app/api/character_names/route.prod.js
@@ -1,5 +1,7 @@
 import { getSession } from '../neo4j_driver/route.prod.js';
 
+export const dynamic = 'force-dynamic';
+
 export const GET = async () => {
   var resGraph;
   try {


### PR DESCRIPTION
Add force-dynamic to /api/character_names route so the character list always queries Neo4j directly instead of serving a cached response.